### PR TITLE
Automate crate publishing

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,14 @@
+name: publish-crate
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  crate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_AUTOMATON_CRATES_IO_API_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hpke-dispatch"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "runtime algorithmic selection for hybrid public key encryption"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/jbr/hpke-dispatch"
+repository = "https://github.com/divviup/hpke-dispatch"
 readme = "./README.md"
 keywords = ["hpke", "encryption"]
 categories = ["cryptography"]


### PR DESCRIPTION
Also bumps the crate version to 0.2.1 so that we can demonstrate that the publish action works, and so `janus` can get on `hpke 0.9.0`.