### PR TITLE
drop `wee_alloc` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["cryptography"]
 cfg_eval = []
 base-mode-open = []
 base-mode-seal = []
-wee-alloc = []
 serde = ["serde_crate"]
 algo-all = ["aead-all", "kdf-all", "kem-all"]
 default = ["algo-all", "base-mode-seal", "base-mode-open"]
@@ -45,7 +44,6 @@ package = "serde"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.80"
 getrandom = { version = "0.2.6", features = ["js", "js-sys"] }
-wee_alloc = "0.4.5"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,6 @@ cfg_if::cfg_if! {
                 Self(h)
             }
         }
-
-        #[cfg_attr(feature = "wee-alloc", global_allocator)]
-        #[cfg(feature = "wee-alloc")]
-        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
     } else {
         pub use hpke::HpkeError;
     }


### PR DESCRIPTION
`wee_alloc` is unmaintained ([1]), which is generating security advisories on `hpke-dispatch` and projects that depend on it. AFAIK, there's no alternative to it that is much better supported, so we drop the dependency altogether and use the std allocator.

[1]: https://github.com/rustwasm/wee_alloc/issues/107