### PR TITLE
Update API token used to publish to crates.io

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/checkout@v3
     - run: cargo publish
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_AUTOMATON_CRATES_IO_API_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_CRATES_IO_API_TOKEN }}


### PR DESCRIPTION
Publish the crate as `divviup-github-automation` rather than `divviup-automaton`, which no longer exists.