### PR TITLE
Implement Display for HpkeError newtype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,12 @@ cfg_if::cfg_if! {
                 Self(h)
             }
         }
+
+        impl core::fmt::Display for HpkeError {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+               core::fmt::Display::fmt(&self.0, f)
+            }
+        }
     } else {
         pub use hpke::HpkeError;
     }


### PR DESCRIPTION
This PR implements Display for our WASM-only newtype around the upstream HpkeError. This should address the warning we were getting about an unused field, as a side effect.