### PR TITLE
Upgrade Node.js in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,9 @@ jobs:
         toolchain: nightly
         override: true
         target: wasm32-unknown-unknown
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "20"
     - uses: jetli/wasm-pack-action@v0.4.0
     - name: build with default features
       run: wasm-pack build

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ from rust, even when opting out of `algo-all`.
   algorithm features. Enabled by default.
 
 * *kem-all*: Enables `kem-dh-p256-hkdf-sha256`,
- `kem-dh-p384-hkdf-sha384`, `kem-dh-p521-hkdf-sha512`, and
- `kem-x25519-hkdf-sha256` algorithm features. Enabled by default.
+  `kem-dh-p384-hkdf-sha384`, `kem-dh-p521-hkdf-sha512`, and
+  `kem-x25519-hkdf-sha256` algorithm features. Enabled by default.
 
 * *serde*: enables derived serde serialization and deserialization for
   all public structs and enums. Disabled by default.


### PR DESCRIPTION
I noticed that a recent CI job failed with a SIGTRAP exception and a bunch of Node.js stack traces. This PR tries installing a newer version of Node.js (the current active LTS release).