### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/base_mode_open.rs
+++ b/src/base_mode_open.rs
@@ -47,13 +47,19 @@ where
     KdfT: hpke::kdf::Kdf,
     KemT: hpke::kem::Kem,
 {
-    hpke::single_shot_open::<AeadT, KdfT, KemT>(
+    let result = hpke::single_shot_open::<AeadT, KdfT, KemT>(
         &hpke::OpModeR::Base,
         &from_bytes(private_key)?,
         &from_bytes(encapped_key)?,
         info,
         ciphertext,
         aad,
-    )
-    .map_err(Into::into) // this is noop unless compiling for wasm.
+    );
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "wasm32")] {
+            result.map_err(Into::into)
+        } else {
+            result
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,14 @@ impl std::fmt::Display for IdLookupError {
 impl std::error::Error for IdLookupError {}
 
 pub(crate) fn from_bytes<T: Deserializable>(encoded: &[u8]) -> Result<T, HpkeError> {
-    T::from_bytes(encoded).map_err(Into::into)
+    let result = T::from_bytes(encoded);
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "wasm32")] {
+            result.map_err(Into::into)
+        } else {
+            result
+        }
+    }
 }
 
 cfg_if::cfg_if! {


### PR DESCRIPTION
This fixes a couple of Clippy warnings by conditionally converting error types, since we conditionally newtype `hpke::HpkeError`.