### PR TITLE
Upgrade dependencies and bump version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""] # for getrandom 0.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpke-dispatch"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "runtime algorithmic selection for hybrid public key encryption"
 license = "MPL-2.0"
@@ -31,10 +31,10 @@ kem-dh-p521-hkdf-sha512 = ["hpke/p521"]
 kem-x25519-hkdf-sha256 = ["hpke/x25519"]
 
 [dependencies]
-rand = "0.8.5"
+rand = "0.9.2"
 num_enum = "0.7.0"
 cfg-if = "1.0.0"
-hpke = { version = "0.12.0", default-features = false, features = ["std"] }
+hpke = { version = "0.13.0", default-features = false, features = ["std"] }
 zeroize = "1.6"
 
 [dependencies.serde_crate]
@@ -43,9 +43,10 @@ features = ["derive"]
 optional = true
 package = "serde"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2.87"
-getrandom = { version = "0.2.10", features = ["js", "js-sys"] }
+getrandom_2 = { package = "getrandom", version = "0.2.16", features = ["js", "js-sys"] } # for getrandom 0.2
+getrandom_3 = { package = "getrandom", version = "0.3.3", features = ["wasm_js"] }       # for getrandom 0.3
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hpke",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hpke",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@tsconfig/node18": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hpke",
   "description": "hybrid public key encryption",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/src/base_mode_seal.rs
+++ b/src/base_mode_seal.rs
@@ -52,7 +52,7 @@ where
         info,
         plaintext,
         aad,
-        &mut rand::thread_rng(),
+        &mut rand::rng(),
     )?;
 
     Ok(EncappedKeyAndCiphertext {

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -68,7 +68,7 @@ impl FromStr for Kem {
 }
 
 impl Kem {
-    /// generate a [`Keypair`] for this [`Config`] or [`Kem`].
+    /// generate a [`Keypair`] for this [`Kem`].
     #[must_use]
     pub fn gen_keypair(self) -> Keypair {
         crate::gen_keypair(self)

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -52,7 +52,7 @@ pub fn gen_keypair(kem: Kem) -> Keypair {
 }
 
 fn gen_kp<KemT: hpke::kem::Kem>() -> Keypair {
-    let (private_key, public_key) = KemT::gen_keypair(&mut rand::thread_rng());
+    let (private_key, public_key) = KemT::gen_keypair(&mut rand::rng());
     let public_key = public_key.to_bytes().to_vec();
     let private_key = private_key.to_bytes().to_vec();
 


### PR DESCRIPTION
This supersedes #69, #73, and #76. We upgrade the `hpke` dependency, which now requires `rand` 0.9. For now, we need to configure both `getrandom` 0.2 and 0.3 to use Javascript shims, using different combinations of config and features. I bumped the version number to 0.8.0 because we expose at least `hpke::HpkeError` in our public API, and because of the above config changes necessary for WASM builds.