### PR TITLE
Use trusted publishing with crates.io

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -7,8 +7,15 @@ on:
 jobs:
   crate:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v6
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - id: auth
+      uses: rust-lang/crates-io-auth-action@v1
     - run: cargo publish
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.DIVVIUP_GITHUB_AUTOMATION_CRATES_IO_API_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This updates the publish-crate workflow to use trusted publishing to authenticate, instead of a token in a secret.